### PR TITLE
Update board.yml

### DIFF
--- a/_data/board.yml
+++ b/_data/board.yml
@@ -196,12 +196,6 @@
     link: "https://arxiv.org/abs/2006.04062"
     venue: NeurIPS 2020
     comment: "under larger attack radius \\(\\epsilon=1.75\\)"
-  - score: 69.79%
-    prob: false
-    title: "Second-Order Provable Defenses against Adversarial Attacks"
-    link: "https://arxiv.org/abs/2006.00731"
-    venue: ICML 2020
-    comment: "non-relu neural networks"
   - score: 69.0%
     prob: true
     title: "Certified adversarial robustness with additive noise"


### PR DESCRIPTION
The reported numbers are wrong. The problem is that they evaluate targeted attack, therefore, even AutoAttack reported lower robust accuracy than this method certifies. It is even written in the paper, section 7, "Unless otherwise specified, we use the class with the second largest logit as the attack target (i.e. the class t)." Therefore I believe this method cannot be included here.

One can also look it up in their code, 
 (on main l. 80 they call certified_acc = test_cert(args, model, device, test_loader), and the test_cert computes certificate only against the runner-up class (line 364 of utils) https://github.com/singlasahil14/so-robust/ 
they also include one trained model in the repo. It is easy to try AutoAttack to find adversarial examples and it will find more of them then the "certificate" would allow.