### PR TITLE
Update readme.md: Fix Citation Capitalization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ This repo contains the leaderboard website of state-of-the-art certified robustn
 If you find this repo helpful, please consider cite our paper:
 ```
 @inproceedings{li2023sok,
-    title={SoK: Certified Robustness for Deep Neural Networks},
+    title={{SoK}: Certified Robustness for Deep Neural Networks},
     author={Linyi Li and Tao Xie and Bo Li},
     booktitle={44th {IEEE} Symposium on Security and Privacy, {SP} 2023, San Francisco, CA, USA, 22-26 May 2023},
     publisher={IEEE},


### PR DESCRIPTION
If a word in the `title` of a `bibtex` citation is mixed case, the word generally should be inside curly brackets. Otherwise, the mixed case capitalization may be lost.  Fixed this issue for `SoK` in your main citation.